### PR TITLE
[style]textカラーの選択肢を追加、画面全体のフォントの大きさ、色、濃さ、行間などをそれぞれ調整

### DIFF
--- a/app/src/components/Caption.tsx
+++ b/app/src/components/Caption.tsx
@@ -26,8 +26,8 @@ const Speaker = styled.p`
 const Word = styled.p<{ color?: string }>`
   margin-top: 0.5rem;
   text-align: initial;
-  font-size: 1.5rem;
-  line-height: 2.5rem;
+  font-size: 1.2rem;
+  line-height: 1.5;
   color: ${({ color }) => color || 'black'};
 `
 

--- a/app/src/config/colors.ts
+++ b/app/src/config/colors.ts
@@ -5,7 +5,11 @@ export const colorSet = {
 }
 
 export default {
-  text: '#001000',
+  text: {
+    default: '#001000',
+    bold: '#709E90',
+    detail: 'rgba(0,0,0,0.8)'
+  },
   background: colorSet.secondary,
   scrollBar: {
     thumb: '#709E90',

--- a/app/src/pages/rooms/[roomId].tsx
+++ b/app/src/pages/rooms/[roomId].tsx
@@ -52,6 +52,22 @@ const ScrollbarContainer = styled.div`
   }
 `
 
+const ReferenceWord = styled.div`
+  font-weight: bold;
+  color: ${colors.text.bold};
+  font-size: 1.8rem;
+  padding-bottom: 1.0rem;
+  letter-spacing:0.2em;
+`
+
+const ReferenceDetail = styled.div`
+  font-family:'メイリオ', 'Meiryo','ＭＳ ゴシック','Hiragino Kaku Gothic ProN','ヒラギノ角ゴ ProN W3',sans-serif;
+  font-size: 1.2rem;
+  color: ${colors.text.detail};
+  line-height: 1.5;
+  word-break: normal;
+`
+
 export const LeftTopBox = styled(LeftBox)`
   border-top: solid 1rem ${colors.borders.left};
   grid-column: 1 / 2;
@@ -99,7 +115,9 @@ const RoomPage: PageFC<{ roomId: string }> = ({ roomId }) => {
           <Control roomId={roomId} user={userStorage} />
         </LeftBottomBox>
         <RightTopBox>
-          {refWord}
+          <ReferenceWord>
+            {refWord}
+          </ReferenceWord>
           {refWord ? (
             <a
               target="_blank"
@@ -113,7 +131,9 @@ const RoomPage: PageFC<{ roomId: string }> = ({ roomId }) => {
         </RightTopBox>
         <RightBottomBox>
           <ScrollbarContainer>
-            <Reference word={refWord} />
+            <ReferenceDetail>
+              <Reference word={refWord} />
+            </ReferenceDetail>
           </ScrollbarContainer>
         </RightBottomBox>
       </GridContainer>


### PR DESCRIPTION
issue: #5 

変更点
---
趣旨はタイトルどおり。
具体的には
- leftBoxのユーザー名とログのサイズをそれぞれ変更
- RightTopBoxのrefWordの大きさ、色、太さを変更、　検索結果を表示で改行
- RightBottomBoxの詳細説明のフォント、大きさ、行間、濃さ、改行のタイミングを文節がきれないように変更。